### PR TITLE
Setting MONGO_URL and MONGO_OPLOG_URL via Docker linking

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![Circle CI](https://circleci.com/gh/meteorhacks/meteord/tree/master.svg?style=svg)](https://circleci.com/gh/meteorhacks/meteord/tree/master)
-## MeteorD - Docker Runtime for Meteor Apps 
+## MeteorD - Docker Runtime for Meteor Apps
 
 There are two main ways you can use Docker with Meteor apps. They are:
 
@@ -35,10 +35,21 @@ docker run -d \
     -e MONGO_URL=mongodb://url \
     -e MONGO_OPLOG_URL=mongodb://oplog_url \
     -p 8080:80 \
-    yourname/app 
+    yourname/app
 ~~~
 
 Then you can access your app from the port 8080 of the host system.
+
+You can also link a MongoDB container to your app container.
+
+~~~shell
+docker run -d \
+    --link <mongodb container name>:mongo
+    -e DB_NAME=<db name>
+    -e ROOT_URL=http://yourapp.com \
+    -p 8080:80 \
+    yourname/app
+~~~
 
 ### 2. Running a Meteor bundle with Docker
 

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ You can also link a MongoDB container to your app container.
 docker run -d \
     --link <mongodb container name>:mongo
     -e DB_NAME=<db name>
+    -e DB_PORT=<db port within mongodb container>
     -e ROOT_URL=http://yourapp.com \
     -p 8080:80 \
     yourname/app

--- a/README.md
+++ b/README.md
@@ -41,7 +41,6 @@ docker run -d \
 Then you can access your app from the port 8080 of the host system.
 
 You can also link a MongoDB container to your app container.
-Note: oplog is not supported yet.
 
 ~~~shell
 docker run -d \
@@ -52,6 +51,22 @@ docker run -d \
     -p 8080:80 \
     yourname/app
 ~~~
+
+If your MongoDB container works with oplog, OPLOG_DB_NAME variable should be set.
+
+~~~shell
+docker run -d \
+    --link <mongodb container name>:mongo
+    -e OPLOG_DB_NAME=<oplog db name, e.g. local>
+    -e DB_NAME=<db name>
+    -e DB_PORT=<db port within mongodb container>
+    -e ROOT_URL=http://yourapp.com \
+    -p 8080:80 \
+    yourname/app
+~~~
+
+NOTE: I tested oplog only with a single replica set instance. See [here](https://medium.com/meteor-secret/adding-oplog-tailing-with-meteor-up-mup-and-ubuntu-efa644f397e9) for further details.
+
 
 ### 2. Running a Meteor bundle with Docker
 

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ docker run -d \
 Then you can access your app from the port 8080 of the host system.
 
 You can also link a MongoDB container to your app container.
+Note: oplog is not supported yet.
 
 ~~~shell
 docker run -d \

--- a/scripts/install_base.sh
+++ b/scripts/install_base.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 apt-get update -y
-apt-get install -y curl wget
+apt-get install -y curl wget syslinux

--- a/scripts/run_app.sh
+++ b/scripts/run_app.sh
@@ -5,7 +5,7 @@ if ! [[ -z ${MONGO_NAME+x} ]]; then
   # resolve name from /etc/hosts
   MONGO_IP_ADDR=$(gethostip -d mongo)
   # override MONGO_URL with the url from the linked container
-  export MONGO_URL=mongodb://$MONGO_IP_ADDR:27017/$DB_NAME
+  export MONGO_URL=mongodb://$MONGO_IP_ADDR:$DB_PORT/$DB_NAME
 fi
 
 if [ -d /bundle ]; then

--- a/scripts/run_app.sh
+++ b/scripts/run_app.sh
@@ -6,6 +6,10 @@ if ! [[ -z ${MONGO_NAME+x} ]]; then
   MONGO_IP_ADDR=$(gethostip -d mongo)
   # override MONGO_URL with the url from the linked container
   export MONGO_URL=mongodb://$MONGO_IP_ADDR:$DB_PORT/$DB_NAME
+  # if user wants to use oplog, defined the corresponding variable
+  if ! [[ -z ${OPLOG_DB_NAME+x} ]]; then
+    export MONGO_OPLOG_URL=mongodb://$MONGO_IP_ADDR:$DB_PORT/$OPLOG_DB_NAME
+  fi
 fi
 
 if [ -d /bundle ]; then

--- a/scripts/run_app.sh
+++ b/scripts/run_app.sh
@@ -1,5 +1,13 @@
 set -e
 
+# check if MongoDB is bound via linking
+if ! [[ -z ${MONGO_NAME+x} ]]; then
+  # resolve name from /etc/hosts
+  MONGO_IP_ADDR=$(gethostip -d mongo)
+  # override MONGO_URL with the url from the linked container
+  export MONGO_URL=mongodb://$MONGO_IP_ADDR:27017/$DB_NAME
+fi
+
 if [ -d /bundle ]; then
   cd /bundle
   tar xzf *.tar.gz


### PR DESCRIPTION
Reference to issue #4 

MongoDB can be provided also via Docker linking. If a link with a MongoDB container exists, then MONGO_URL and MONGO_OPLOG_URL variables are built automatically from the IP address of the source linked container. Otherwise, these variables are required on the command line as usual.

I suppose MONGO_OPLOG_URL and MONGO_URL has the same base address. I do not know if it is too restrictive. I tested it using a simple MongoDb with a single replica set.
