### PR TITLE
Install meteor before copying app content

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ RUN bash /opt/meteord/install_base.sh
 RUN bash /opt/meteord/install_node.sh
 RUN bash /opt/meteord/install_phantomjs.sh
 
+ONBUILD RUN bash /opt/meteord/install_meteor.sh
 ONBUILD COPY ./ /app
 ONBUILD RUN bash /opt/meteord/meteord-build.sh
 

--- a/scripts/install_meteor.sh
+++ b/scripts/install_meteor.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+curl https://install.meteor.com | /bin/sh

--- a/scripts/meteord-build.sh
+++ b/scripts/meteord-build.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-curl https://install.meteor.com | /bin/sh
 
 cd /app
 meteor build --directory /tmp/the-app


### PR DESCRIPTION
This PR modifies Dockerfile to install meteor before copying app content to leverage image cache.

With this modification, one doesn't need to re-download meteor everytime he builds a new app image after modify his code.
