### PR TITLE
tweak so the meteor build goes through

### DIFF
--- a/scripts/meteord-build.sh
+++ b/scripts/meteord-build.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 cd /app
-meteor build --directory /tmp/the-app
+meteor build --directory /tmp/the-app --server=localhost
 
 cd /tmp/the-app/bundle/programs/server/
 npm i


### PR DESCRIPTION
For some reason when I try to build the bundle without the --server option I get
"Supply the server hostname and port in the --server option for mobile app builds." message and the build stops.
After adding --server=localhost this goes through. 

This might be a bug in the meteor as the default should be set automatically, but, nonetheless, for now, this is a way to get meteord to work with option 1. 
