### PR TITLE
Added known issue relating to Joyent's Triton.

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,8 +98,25 @@ docker run -d \
 
 ## Known Issues
 
-#### Spiderable Not Wokring (But, have a fix)
+#### Spiderable Not Working (But, have a fix)
 
 There are some issues when running spiderable inside a Docker container. For that, check this issue: https://github.com/meteor/meteor/issues/2429
 
 Fortunately, there is a fix. Simply use [`ongoworks:spiderable`](https://github.com/ongoworks/spiderable) instead the official package.
+
+#### Container won't start on Joyent's Triton infrastructure
+
+There's currently (2015-07-18) an issue relating to how the command or entry point is parsed, so containers won't boot using the 'docker run' commands as above. 
+
+Instead, Joyent support has suggested the following workaround until their fix can be rolled out.
+
+~~~shell
+docker run -d \
+    -e ROOT_URL=http://yourapp.com \
+    -e MONGO_URL=mongodb://url \
+    -e MONGO_OPLOG_URL=mongodb://oplog_url \
+    -p 80:80 \
+    --entrypoint=bash \
+    yourname/app \
+    /opt/meteord/run_app.sh
+~~~


### PR DESCRIPTION
There's currently an issue relating to starting meteord containers on Joyent's Triton Infrastructure. I've been back and forth with Joyent's support team (Peter Gale and Andrew Hill) and they've come up with this workaround. They have a proper fix, but they told me it might take a while to roll out to production, so they gave me this work around to use in the meantime.

Once the fix has been rolled out, this can be removed, but there's currently no ETA for this to happen. I thought I'd share this here to save others some headaches.
