### PR TITLE
Honour already existing PORT variable

### DIFF
--- a/base/scripts/run_app.sh
+++ b/base/scripts/run_app.sh
@@ -31,6 +31,7 @@ if [[ $REBULD_NPM_MODULES ]]; then
   fi
 fi
 
-export PORT=80
+# Honour already existing PORT setup
+export PORT=${PORT:-80}
 echo "=> Starting meteor app on port:$PORT"
 node main.js


### PR DESCRIPTION
[Dokku](http://progrium.viewdocs.io/dokku/) uses Nginx for proxying in front of Docker containers. Currently the setup seems fixed to port **5000** which meant that it could not connect to `meteord` container which was fixed to port **80**.

This patch exports `PORT` if that was already set while defaulting to `80` if it was not, so that Docker configuration can override the port.

(This was needed to get Rocket.Chat working in Dokku)
