### PR TITLE
Be kind to those building images on CI infrastructure.

### DIFF
--- a/base/scripts/lib/install_meteor.sh
+++ b/base/scripts/lib/install_meteor.sh
@@ -1,3 +1,3 @@
 set -e
 
-curl https://install.meteor.com | /bin/sh
+curl -sL https://install.meteor.com | sed s/--progress-bar/-sL/g | /bin/sh


### PR DESCRIPTION
By default, curl produces verbose progress output that typically explodes the logs as recorded by many Continuous Integration systems.

This is a simple change that just makes it easier to work with these base images in general.  I'm not sure if there's any particular reason why one would want to see curl's default output, but I don't really care so I figured most devs wouldn't either.
