### PR TITLE
honour kubernetes env vars to build MONGO_URL

### DIFF
--- a/base/scripts/run_app.sh
+++ b/base/scripts/run_app.sh
@@ -40,5 +40,30 @@ fi
 # Honour already existing PORT setup
 export PORT=${PORT:-80}
 
+# map kubernetes service env vars
+# get the kubernetes mongo service name from K8S_MONGO_SERVICE_ENV_NAME
+# and expand it to the resulting MONGO_URL
+# if K8S_MONGO_DB_NAME is set, it gets appended to MONGO_URL
+# ex.
+# given by k8s env:
+# MYAPP_MONGO_SERVICE_HOST="host"
+# MYAPP_MONGO_SERVICE_PORT=27018
+# set in Dockerfile/controller.json
+# K8S_MONGO_SERVICE_ENV_NAME="MYAPP_MONGO"
+# K8S_MONGO_DB_NAME="myapp_prod"
+# results in:
+# MONGO_URL: mongodb://host:27018:/myapp_prod
+if [[ $K8S_MONGO_SERVICE_ENV_NAME ]]; then
+  MONGO_HOST_VAR=${K8S_MONGO_SERVICE_ENV_NAME}_SERVICE_HOST
+  MONGO_PORT_VAR=${K8S_MONGO_SERVICE_ENV_NAME}_SERVICE_PORT
+
+  MONGO_URL=mongodb://${!MONGO_HOST_VAR}:${!MONGO_PORT_VAR}
+  if [[ $K8S_MONGO_DB_NAME ]]; then
+    MONGO_URL=${MONGO_URL}:/${K8S_MONGO_DB_NAME}
+  fi
+  export MONGO_URL=${MONGO_URL}
+  echo "Use MONGO_URL: $MONGO_URL"
+fi
+
 echo "=> Starting meteor app on port:$PORT"
 node main.js


### PR DESCRIPTION
I added this feature to be able to use the build docker images with kubernetes.
Kubernetes automagically maintains ENV vars in pods/containers containing IP/port informations of neighboring services of the same cluster. To be able to run meteor in kubernets, the app container needs to find the IP/port of the mongo service. Because the mongo service name may vary depending of one's individual setup, I added the functionality to state the name of it and evaluate the corresponding env var set by kubernetes to connect to mongo.

As it can be seen in this issue, the kubernetes env var should be evaluated by the app.
https://github.com/kubernetes/kubernetes/issues/1331

Another example of using the same strategy is the nginx example by google, using SERVICE_HOST_ENV_NAME in start.sh
https://github.com/GoogleCloudPlatform/nginx-ssl-proxy/blob/master/start.sh

get the kubernetes mongo service name from K8S_MONGO_SERVICE_ENV_NAME
and expand it to the resulting MONGO_URL
if K8S_MONGO_DB_NAME is set, it gets appended to MONGO_URL
ex.
given by k8s env:
MYAPP_MONGO_SERVICE_HOST="host"
MYAPP_MONGO_SERVICE_PORT=27018
set in Dockerfile/controller.json
K8S_MONGO_SERVICE_ENV_NAME="MYAPP_MONGO"
K8S_MONGO_DB_NAME="myapp_prod"
results in:
MONGO_URL: mongodb://host:27018:/myapp_prod
