### PR TITLE
Introduce volbuild, a way to bind-mount code when developing locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
->MeteorD is no longer used by SignMeUp, deprecated in favor of a smaller, local Dockerfile. Check the main repo for the latest version.
+>MeteorD is no longer used by SignMeUp in production, deprecated in favor of a smaller, local Dockerfile. Check the main repo for the latest version. We still use it for local development from time to time, but new solutions are being explored.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
-[![Circle CI](https://circleci.com/gh/meteorhacks/meteord/tree/master.svg?style=svg)](https://circleci.com/gh/meteorhacks/meteord/tree/master)
+>MeteorD is no longer used by SignMeUp, deprecated in favor of a smaller, local Dockerfile. Check the main repo for the latest version.
+
+---
+
 ## MeteorD - Docker Runtime for Meteor Apps 
 
 There are two main ways you can use Docker with Meteor apps. They are:

--- a/base/scripts/run_app.sh
+++ b/base/scripts/run_app.sh
@@ -39,17 +39,17 @@ if [[ $DELAY ]]; then
   sleep $DELAY
 fi
 
-# Honour already existing PORT setup
-export PORT=${PORT:-80}
-
-echo "=> Starting meteor app on port:$PORT"
-
 if [[ $METEORD_VOLBUILD ]]; then
-  if [[ $SETTINGS_PATH ]]; then
-    meteor --settings $SETTINGS_PATH --port $PORT
+  if [[ $ARGS ]]; then
+    echo "=> Starting meteor app with args: $ARGS"
+    meteor $ARGS
   else
-    meteor --port $PORT
+    echo "=> Starting meteor app"
+    meteor
   fi
 else
+  # Honour already existing PORT setup
+  export PORT=${PORT:-80}
+  echo "=> Starting meteor app on port:$PORT"
   node main.js
 fi

--- a/base/scripts/run_app.sh
+++ b/base/scripts/run_app.sh
@@ -15,6 +15,8 @@ elif [[ $BUNDLE_URL ]]; then
   cd /tmp/bundle/
 elif [ -d /built_app ]; then
   cd /built_app
+elif [[ $METEORD_VOLBUILD ]]; then
+  cd /app
 else
   echo "=> You don't have an meteor app to run in this image."
   exit 1
@@ -41,4 +43,13 @@ fi
 export PORT=${PORT:-80}
 
 echo "=> Starting meteor app on port:$PORT"
-node main.js
+
+if [[ $METEORD_VOLBUILD ]]; then
+  if [[ $SETTINGS_PATH ]]; then
+    meteor --settings $SETTINGS_PATH --port $PORT
+  else
+    meteor --port $PORT
+  fi
+else
+  node main.js
+fi

--- a/base/scripts/run_app.sh
+++ b/base/scripts/run_app.sh
@@ -40,15 +40,12 @@ if [[ $DELAY ]]; then
 fi
 
 if [[ $METEORD_VOLBUILD ]]; then
-  if [[ $ARGS ]]; then
-    echo "=> Starting meteor app with args: $ARGS"
-    meteor $ARGS
-  else
-    echo "=> Starting meteor app"
-    meteor
-  fi
+  # Default port 80; if ARGS provided, they should include "--port 80"
+  export ARGS=${ARGS:---port 80}
+  echo "=> Starting meteor app with args: $ARGS"
+  meteor $ARGS
 else
-  # Honour already existing PORT setup
+  # Default port 80; honor an override
   export PORT=${PORT:-80}
   echo "=> Starting meteor app on port:$PORT"
   node main.js

--- a/volbuild/Dockerfile
+++ b/volbuild/Dockerfile
@@ -1,4 +1,4 @@
-FROM athyuttamre/meteord:base
+FROM meteorhacks/meteord:base
 MAINTAINER MeteorHacks Pvt Ltd.
 
 ONBUILD ENV METEORD_VOLBUILD=true

--- a/volbuild/Dockerfile
+++ b/volbuild/Dockerfile
@@ -1,0 +1,7 @@
+FROM athyuttamre/meteord:base
+MAINTAINER MeteorHacks Pvt Ltd.
+
+ONBUILD ENV METEORD_VOLBUILD=true
+
+ONBUILD RUN bash $METEORD_DIR/lib/install_meteor.sh
+ONBUILD VOLUME /app


### PR DESCRIPTION
I'd like to introduce and open for discussion a new image: `volbuild`. This bind-mounts the codebase into the Docker container and runs `meteor`. An ability to provide arguments is provided.
## Philosophy

I think Docker's core idea is that if something works on your laptop, it will work anywhere (including your server.) For this to be realistic, the developer must edit code while running the app within a Docker environment. However, building and running a Node bundle each time is slow, cumbersome, and non-Meteoric. 

Bind-mounting code, on the other hand, allows for hot code push as well as the standard Meteor runtime, all while maintaining the isolated environment.

Some have expressed that this should've been `devbuild` originally. To not break backwards compatibility, I've created a new name `volbuild`.
## Notes

If accepted, we should probably mention in the README that while by default `ARGS` has a value of `--port 80`, if it is overridden, the new value must include `--port 80` for it to work as expected. Otherwise Meteor will run with port 3000. If someone has ideas to do this within the code itself (I'm new to bash scripting), by all means welcome.

Also, if you've been running your code on your host machine, sometimes the `.meteor/local` directory messes up builds within the container. In this case the user should delete that folder and rerun.

Finally, this method seems to show a significant delay between `=> Starting proxy` to `=> Your app is running at http://domain:80`. Not sure why.
