### PR TITLE
Update PhantomJS to 2.1.1

### DIFF
--- a/base/scripts/lib/install_phantomjs.sh
+++ b/base/scripts/lib/install_phantomjs.sh
@@ -2,7 +2,7 @@
 set -e
 apt-get -y install libfreetype6 libfreetype6-dev fontconfig
 ARCH=`uname -m`
-PHANTOMJS_VERSION=1.9.8
+PHANTOMJS_VERSION=2.1.1
 PHANTOMJS_TAR_FILE=phantomjs-${PHANTOMJS_VERSION}-linux-${ARCH}.tar.bz2
 
 cd /usr/local/share/


### PR DESCRIPTION
Please update PhantomJS to the latest stable version. PhantomJS 2.1 was released in January 2016.
