### PR TITLE
node v4 will node-gyp command fail

### DIFF
--- a/binbuild/scripts/install_binbuild_tools.sh
+++ b/binbuild/scripts/install_binbuild_tools.sh
@@ -2,6 +2,7 @@ set -e
 # for npm module re-building
 apt-get -y install build-essential libssl-dev git python
 npm install -g node-gyp
+ln -sf /opt/nodejs/bin/node-gyp /usr/bin/node-gyp
 # pre-install node source code for faster building
 node-gyp install ${NODE_VERSION}
 


### PR DESCRIPTION
Fixing this error: 

```
/opt/meteord/install_binbuild_tools.sh: line 14: node-gyp: command not found
The command '/bin/sh -c bash $METEORD_DIR/install_binbuild_tools.sh' returned a non-zero code: 127
```
