### PR TITLE
Fix for 'You are attempting to run Meteor as the "root" user' issue

### DIFF
--- a/base/scripts/lib/build_app.sh
+++ b/base/scripts/lib/build_app.sh
@@ -8,7 +8,7 @@ BUNDLE_DIR=/tmp/bundle-dir
 cp -R /app $COPIED_APP_PATH
 cd $COPIED_APP_PATH
 
-meteor build --directory $BUNDLE_DIR --server=http://localhost:3000
+meteor build --unsafe-perm --directory $BUNDLE_DIR --server=http://localhost:3000
 
 cd $BUNDLE_DIR/bundle/programs/server/
 npm i


### PR DESCRIPTION
This is a simple fix for the issue described on https://github.com/meteor/meteor/issues/7959. Latest version of meteor cli doesn't allow the build command to run as root user, which broke the docker build.
